### PR TITLE
Fix network IO bug

### DIFF
--- a/src/main/java/thedarkcolour/exdeorum/recipe/barrel/BarrelFluidMixingRecipe.java
+++ b/src/main/java/thedarkcolour/exdeorum/recipe/barrel/BarrelFluidMixingRecipe.java
@@ -112,6 +112,7 @@ public class BarrelFluidMixingRecipe implements Recipe<Container> {
             buffer.writeVarInt(recipe.baseFluidAmount);
             buffer.writeRegistryId(ForgeRegistries.FLUIDS, recipe.additiveFluid);
             buffer.writeRegistryId(ForgeRegistries.ITEMS, recipe.result);
+            buffer.writeBoolean(recipe.consumesAdditive);
         }
 
         @Override


### PR DESCRIPTION
I think you may forget to send consumesAdditive property to the network.
My friend is running a server with your mod. When updated to 1.18, the client cannot connect to the server with such bug:
![c122e24ebd82b84de4df46be471feac1](https://github.com/thedarkcolour/ExDeorum/assets/115922715/f3d4dea3-8604-4ff3-b2db-a8cb1ad27bf7)
I fixed the bug in this commit.