### PR TITLE
Fix NullPointerException

### DIFF
--- a/src/main/java/thedarkcolour/exdeorum/client/CompostColors.java
+++ b/src/main/java/thedarkcolour/exdeorum/client/CompostColors.java
@@ -152,7 +152,10 @@ public class CompostColors {
 
             if (!readMods.contains(modid)) {
                 var id = entry.getKey().location().getPath();
-                var jarFile = ModList.get().getModFileById(modid).getFile();
+                var modFile = ModList.get().getModFileById(modid);
+                if (modFile == null)
+                    continue;
+                var jarFile = modFile.getFile();
                 var modelPath = jarFile.findResource("assets/" + modid + "/models/item/" + id + ".json");
 
                 if (Files.exists(modelPath)) {


### PR DESCRIPTION
When I update Ex Deorum to 1.19, the server crashes whenever I look at a barrel.
log:
[crash-2024-01-30_11.02.24-server.txt](https://github.com/thedarkcolour/ExDeorum/files/14105941/crash-2024-01-30_11.02.24-server.txt)
I don't know why this happens. I make a small change, and everything goes well.
If you can fix the bug from the root, it's better.
My solution seems to be enough to work.