### PR TITLE
Add sieve interval

### DIFF
--- a/src/main/java/thedarkcolour/exdeorum/blockentity/MechanicalSieveBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/MechanicalSieveBlockEntity.java
@@ -83,7 +83,7 @@ public class MechanicalSieveBlockEntity extends AbstractMachineBlockEntity<Mecha
 
     @Override
     protected void runMachineTick() {
-        this.logic.sift(0.01f);
+        this.logic.sift(0.01f, Long.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/thedarkcolour/exdeorum/blockentity/SieveBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/SieveBlockEntity.java
@@ -109,6 +109,7 @@ public class SieveBlockEntity extends AbstractSieveBlockEntity {
                     }
                 }
             } else {
+                var time = level.getGameTime();
                 var realPlayer = !(player instanceof FakePlayer);
 
                 if (realPlayer && EConfig.SERVER.simultaneousSieveUsage.get()) {
@@ -121,7 +122,7 @@ public class SieveBlockEntity extends AbstractSieveBlockEntity {
                             if (level.getBlockEntity(cursor) instanceof SieveBlockEntity other) {
                                 if (!other.logic.getContents().isEmpty()) {
                                     if (this.logic.getMesh().getItem() == other.logic.getMesh().getItem()) {
-                                        other.logic.sift(SIEVE_INTERVAL);
+                                        other.logic.sift(SIEVE_INTERVAL, time);
                                     }
                                 }
                             }
@@ -130,7 +131,7 @@ public class SieveBlockEntity extends AbstractSieveBlockEntity {
                         cursor.move(1, 0, (-2 * range) - 1);
                     }
                 } else if (realPlayer || EConfig.SERVER.automatedSieves.get()) {
-                    this.logic.sift(SIEVE_INTERVAL);
+                    this.logic.sift(SIEVE_INTERVAL, time);
                 }
             }
         }

--- a/src/main/java/thedarkcolour/exdeorum/blockentity/logic/SieveLogic.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/logic/SieveLogic.java
@@ -45,11 +45,14 @@ public class SieveLogic {
     private float progress;
     private float efficiency;
     private int fortune;
+    private long lastTime = 0;
+    private final long minInterval;
 
     public SieveLogic(Owner owner, boolean saveMesh, boolean mechanical) {
         this.owner = owner;
         this.saveMesh = saveMesh;
         this.mechanical = mechanical;
+        this.minInterval = EConfig.SERVER.sieveIntervalTicks.get();
     }
 
     public ItemStack getMesh() {
@@ -71,7 +74,11 @@ public class SieveLogic {
     }
 
     // Do not call on the client side
-    public void sift(float incrementProgress) {
+    public void sift(float incrementProgress, long time) {
+        if (time < lastTime + minInterval)
+            return;
+        lastTime = time;
+
         this.progress += incrementProgress * this.efficiency;
 
         // Need epsilon because floating point decimals suck

--- a/src/main/java/thedarkcolour/exdeorum/blockentity/logic/SieveLogic.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/logic/SieveLogic.java
@@ -75,10 +75,11 @@ public class SieveLogic {
 
     // Do not call on the client side
     public void sift(float incrementProgress, long time) {
-        if (time < lastTime + minInterval)
+        if (time < this.lastTime + this.minInterval) {
             return;
-        lastTime = time;
-
+        }
+        
+        this.lastTime = time;
         this.progress += incrementProgress * this.efficiency;
 
         // Need epsilon because floating point decimals suck

--- a/src/main/java/thedarkcolour/exdeorum/config/EConfig.java
+++ b/src/main/java/thedarkcolour/exdeorum/config/EConfig.java
@@ -135,6 +135,7 @@ public class EConfig {
         public final IntValue mechanicalSieveEnergyConsumption;
         public final IntValue mechanicalHammerEnergyStorage;
         public final IntValue mechanicalHammerEnergyConsumption;
+        public final IntValue sieveIntervalTicks;
 
         public Server(ForgeConfigSpec.Builder builder) {
             builder.comment("Server configuration for Ex Deorum").push("server");
@@ -187,7 +188,9 @@ public class EConfig {
             this.mechanicalHammerEnergyConsumption = builder
                     .comment("The amount of FE/t a tick consumed by the mechanical hammer when crushing a block.")
                     .defineInRange("mechanical_hammer_energy_consumption", 20, 0, Integer.MAX_VALUE);
-
+            this.sieveIntervalTicks = builder
+                    .comment("The minimum interval ticks between two sifting operation. Only for handy sifting. 0 means no limit.")
+                    .defineInRange("sieve_interval", 1, 0, Integer.MAX_VALUE);
             builder.pop();
         }
     }

--- a/src/main/java/thedarkcolour/exdeorum/config/EConfig.java
+++ b/src/main/java/thedarkcolour/exdeorum/config/EConfig.java
@@ -189,7 +189,7 @@ public class EConfig {
                     .comment("The amount of FE/t a tick consumed by the mechanical hammer when crushing a block.")
                     .defineInRange("mechanical_hammer_energy_consumption", 20, 0, Integer.MAX_VALUE);
             this.sieveIntervalTicks = builder
-                    .comment("The minimum interval ticks between two sifting operation. Only for handy sifting. 0 means no limit.")
+                    .comment("The minimum number of ticks a player must wait between two sifting operations. Only affects sifting by hand. 0 means no limit.")
                     .defineInRange("sieve_interval", 1, 0, Integer.MAX_VALUE);
             builder.pop();
         }


### PR DESCRIPTION
Some players of my modpack use auto clicker on sieve. It is incredibly and unreasonably efficient. I think modpack author should be able to disable that. So I add a config to limit the frquency of handy sifting. 