### PR TITLE
Transfer water bottle NBT data to the fluid placed in barrels (Thirst Was Taken support)

### DIFF
--- a/src/main/java/thedarkcolour/exdeorum/blockentity/BarrelBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/BarrelBlockEntity.java
@@ -246,6 +246,11 @@ public class BarrelBlockEntity extends ETankBlockEntity {
                     var fluid = new FluidStack(Fluids.WATER, 250);
 
                     if (playerItem.getItem() == Items.POTION && PotionUtils.getPotion(playerItem) == Potions.WATER) {
+                    	// Transfer any extra NBT tags from other mods to the fluid
+                    	 var nbt = playerItem.getTag().copy();
+                    	 nbt.remove("Potion");
+                    	 fluid = new FluidStack(Fluids.WATER, 250, nbt);
+
                         if (this.tank.fill(fluid, IFluidHandler.FluidAction.SIMULATE) > 0) {
                             if (!player.getAbilities().instabuild) {
                                 player.setItemInHand(hand, new ItemStack(Items.GLASS_BOTTLE));
@@ -257,6 +262,11 @@ public class BarrelBlockEntity extends ETankBlockEntity {
                             return InteractionResult.sidedSuccess(level.isClientSide);
                         }
                     } else if (playerItem.getItem() == Items.GLASS_BOTTLE) {
+                    	// Check if current fluid is water and use any NBT data
+                    	var currentFluid = this.tank.getFluid();
+                    	if (currentFluid.getRawFluid() == Fluids.WATER) {
+                    		fluid.setTag(currentFluid.getTag());
+                    	}
                         if (this.tank.drain(fluid, IFluidHandler.FluidAction.SIMULATE).getAmount() == 250) {
                             extractWaterBottle(this.tank, level, player, playerItem, fluid);
 
@@ -314,6 +324,8 @@ public class BarrelBlockEntity extends ETankBlockEntity {
             playerItem.shrink(1);
         }
         var bottle = PotionUtils.setPotion(new ItemStack(Items.POTION), Potions.WATER);
+        var nbt = bottle.getOrCreateTag();
+        nbt.merge(fluid.getOrCreateTag());
         if (!player.addItem(bottle)) {
             player.drop(bottle, false);
         }


### PR DESCRIPTION
I've been using this mod alongside [Thirst Was Taken](https://www.curseforge.com/minecraft/mc-mods/thirst-was-taken) in a [modpack I've been working on recently](https://www.curseforge.com/minecraft/modpacks/crashed). It uses NBT data on regular water for varying the quality of water instead of creating different liquids, which makes it easy to use in a modpack compatibility wise.

I noticed that when I placed and picked up liquid from barrels using bottles the NBT data was lost. This PR fixes that to support Thirst Was Taken as well as any other mod that modifies water NBT.