### PR TITLE
[1.20.1] Some Barrel NBT transfer bug fixes and a map color for dust

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,7 @@ dependencies {
     //modImplementation("curse.maven:inventorysorter-240633:4655091")
     modImplementation("curse.maven:cyclic-239286:4994392")
     modImplementation("curse.maven:flib-661261:4724762")
+    modImplementation("curse.maven:thirst-was-taken-679270:6660408")
 
     // DEV ONLY
     compileOnly('org.jetbrains:annotations:23.0.0')

--- a/src/main/java/thedarkcolour/exdeorum/blockentity/BarrelBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/BarrelBlockEntity.java
@@ -249,6 +249,7 @@ public class BarrelBlockEntity extends ETankBlockEntity {
                     	// Transfer any extra NBT tags from other mods to the fluid
                     	 var nbt = playerItem.getTag().copy();
                     	 nbt.remove("Potion");
+                         if (nbt.isEmpty()) nbt = null;
                     	 fluid = new FluidStack(Fluids.WATER, 250, nbt);
 
                         if (this.tank.fill(fluid, IFluidHandler.FluidAction.SIMULATE) > 0) {

--- a/src/main/java/thedarkcolour/exdeorum/blockentity/BarrelBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/BarrelBlockEntity.java
@@ -335,13 +335,15 @@ public class BarrelBlockEntity extends ETankBlockEntity {
         if (!player.getAbilities().instabuild) {
             playerItem.shrink(1);
         }
+        tank.drain(fluid, IFluidHandler.FluidAction.EXECUTE);
         var bottle = PotionUtils.setPotion(new ItemStack(Items.POTION), Potions.WATER);
-        var nbt = bottle.getOrCreateTag();
-        nbt.merge(fluid.getOrCreateTag());
+        if (fluid.hasTag()) {
+            var nbt = bottle.getOrCreateTag();
+            nbt.merge(fluid.getTag());
+        }
         if (!player.addItem(bottle)) {
             player.drop(bottle, false);
         }
-        tank.drain(fluid, IFluidHandler.FluidAction.EXECUTE);
         level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.BOTTLE_EMPTY, SoundSource.NEUTRAL, 1.0F, 1.0F);
     }
 

--- a/src/main/java/thedarkcolour/exdeorum/blockentity/BarrelBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/BarrelBlockEntity.java
@@ -226,6 +226,54 @@ public class BarrelBlockEntity extends ETankBlockEntity {
             var wasBurning = isBurning();
 
             this.isBeingFilledByPlayer = true;
+            var playerItem = player.getItemInHand(hand);
+
+            // Insert water bucket with NBT
+            if (playerItem.getItem() == Items.WATER_BUCKET && playerItem.hasTag()) {
+                var fluid = new FluidStack(Fluids.WATER, 1000, playerItem.getTag().copy());
+                if (this.tank.fill(fluid, IFluidHandler.FluidAction.SIMULATE) == 1000) {
+                    this.tank.fill(fluid, IFluidHandler.FluidAction.EXECUTE);
+                    if (!player.getAbilities().instabuild) {
+                        playerItem.shrink(1);
+                        if (!player.addItem(new ItemStack(Items.BUCKET))) {
+                            player.drop(new ItemStack(Items.BUCKET), false);
+                        }
+                    }
+                    level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.BUCKET_EMPTY, SoundSource.NEUTRAL, 1.0F, 1.0F);
+                    this.isBeingFilledByPlayer = false;
+                    tryInWorldFluidMixing();
+                    markUpdated();
+
+                    if (wasBurning && !isHotFluid(this.tank.getFluid().getFluid().getFluidType())) {
+                        this.progress = 0.0f;
+                    }
+
+                    return InteractionResult.sidedSuccess(level.isClientSide);
+                }
+            }
+
+            // Extract liquid with NBT
+            if (playerItem.getItem() == Items.BUCKET) {
+                var currentFluid = this.tank.getFluid();
+                if (currentFluid.getFluid() == Fluids.WATER && currentFluid.hasTag() && currentFluid.getAmount() >= 1000) {
+                    if (this.tank.drain(1000, IFluidHandler.FluidAction.SIMULATE).getAmount() == 1000) {
+                        this.tank.drain(1000, IFluidHandler.FluidAction.EXECUTE);
+                        var filledBucket = new ItemStack(Items.WATER_BUCKET);
+                        filledBucket.setTag(currentFluid.getTag().copy());
+                        if (!player.getAbilities().instabuild) {
+                            playerItem.shrink(1);
+                            if (!player.addItem(filledBucket)) {
+                                player.drop(filledBucket, false);
+                            }
+                        }
+                        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.BUCKET_FILL, SoundSource.NEUTRAL, 1.0F, 1.0F);
+                        this.isBeingFilledByPlayer = false;
+                        tryInWorldFluidMixing();
+                        markUpdated();
+                        return InteractionResult.sidedSuccess(level.isClientSide);
+                    }
+                }
+            }
 
             if (FluidUtil.interactWithFluidHandler(player, hand, this.tank)) {
                 this.isBeingFilledByPlayer = false;
@@ -241,7 +289,6 @@ public class BarrelBlockEntity extends ETankBlockEntity {
             } else {
                 this.isBeingFilledByPlayer = false;
                 // try one more time to transfer fluids between item and barrel
-                var playerItem = player.getItemInHand(hand);
                 if (EConfig.SERVER.allowWaterBottleTransfer.get()) {
                     var fluid = new FluidStack(Fluids.WATER, 250);
 

--- a/src/main/java/thedarkcolour/exdeorum/registry/EBlocks.java
+++ b/src/main/java/thedarkcolour/exdeorum/registry/EBlocks.java
@@ -41,7 +41,7 @@ public class EBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, ExDeorum.ID);
 
     // Materials
-    public static final RegistryObject<Block> DUST = BLOCKS.register("dust", () -> new FallingBlock(of().sound(SoundType.SAND).strength(0.4f)));
+    public static final RegistryObject<Block> DUST = BLOCKS.register("dust", () -> new FallingBlock(of().mapColor(MapColor.SAND).sound(SoundType.SAND).strength(0.4f)));
     public static final RegistryObject<Block> CRUSHED_NETHERRACK = BLOCKS.register("crushed_netherrack", () -> new FallingBlock(of().mapColor(MapColor.NETHER).sound(SoundType.SAND).strength(0.6f)));
     public static final RegistryObject<Block> CRUSHED_END_STONE = BLOCKS.register("crushed_end_stone", () -> new FallingBlock(of().mapColor(MapColor.SAND).sound(SoundType.SAND).strength(0.6f)));
     public static final RegistryObject<Block> CRUSHED_DEEPSLATE = BLOCKS.register("crushed_deepslate", () -> new FallingBlock(of().mapColor(DyeColor.GRAY).sound(SoundType.SAND).strength(0.8f)));


### PR DESCRIPTION
This pull request fixes some bugs related to fluid NBT storage in barrels and adds slightly more support for it. This will improve compatibility with mods that use fluid NBT, like [Thirst Was Taken](https://modrinth.com/mod/thirst-was-taken). For testing, Thirst Was Taken has been added to the development environment.
It also fixes #169 by adding a map color to dust.

## Bug Fixes

* Fixed an issue where filling a water bottle from a barrel would fill the bottle but not drain the barrel due to mismatched NBT values. To fix this, the drain operation is moved before the NBT operations.
* Fixed issues when transferring water between a barrel and a bottle where empty NBT tags (ex: "{}") would be transferred to the fluid unnecessarily. This led to water from bottles and buckets being treated as different liquids due to the presence of empty NBT on the water from the bottles. To fix this, null values are used when the NBT tag is empty instead of "{}".

## Improvements

* Improved compatibility by allowing fluid NBT to be transferred from water buckets as well as bottles. This allows NBT data to be preserved from the bucket when depositing or extracting water with NBT and fixes some issues with Thirst Was Taken's water purity system. To fix this, water buckets with NBT are handled before normal tank transfer mechanics and copy NBT between the fluid and the item.
* Set the map color of Dust to fix #169 and allow it to display properly when used in worldgen.

I am happy to answer any questions about these changes, just let me know.