### PR TITLE
Backport compressed sieve fix

### DIFF
--- a/src/main/java/thedarkcolour/exdeorum/blockentity/AbstractSieveBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/AbstractSieveBlockEntity.java
@@ -160,7 +160,7 @@ public abstract class AbstractSieveBlockEntity extends EBlockEntity implements S
                                 }
 
                                 if ((x | z) != 0) {
-                                    if (level.getBlockEntity(cursor) instanceof SieveBlockEntity other) {
+                                    if (level.getBlockEntity(cursor) instanceof AbstractSieveBlockEntity other && other.getType() == getType()) {
                                         var otherLogic = other.logic;
 
                                         if (otherLogic.getContents().isEmpty()) {


### PR DESCRIPTION
I've backported the compressed sieve adjacent fix. No idea if this PR will be accepted, but its mainly here for visibility. I just wanted to use the fix in a 1.21 pack I'm playing. I attached the fix jar (or you can just clone this branch and build it yourself (`./gradlew build`).

[exdeorum-3.10.zip](https://github.com/user-attachments/files/28326862/exdeorum-3.10.zip)
