### PR TITLE
[1.20.1] Avoid unsafe crucible block entity lookups during chunk loading

### DIFF
--- a/src/main/java/thedarkcolour/exdeorum/block/AbstractCrucibleBlock.java
+++ b/src/main/java/thedarkcolour/exdeorum/block/AbstractCrucibleBlock.java
@@ -26,6 +26,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -50,8 +51,19 @@ public abstract class AbstractCrucibleBlock extends ETankBlock {
 
     @Override
     public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
-        if (level.getExistingBlockEntity(pos) instanceof AbstractCrucibleBlockEntity crucible) {
-            return crucible.getTank().getFluid().getFluid().getFluidType().getLightLevel();
+        BlockEntity blockEntity = null;
+
+        if (level instanceof LevelChunk chunk) {
+            blockEntity = chunk.getBlockEntity(pos, LevelChunk.EntityCreationType.CHECK);
+        } else if (level instanceof Level world) {
+            var chunk = world.getChunkSource().getChunkNow(pos.getX() >> 4, pos.getZ() >> 4);
+            if (chunk != null) {
+                blockEntity = chunk.getBlockEntity(pos, LevelChunk.EntityCreationType.CHECK);
+            }
+        }
+
+        if (blockEntity instanceof AbstractCrucibleBlockEntity crucible) {
+            return Mth.clamp(crucible.getTank().getFluid().getFluid().getFluidType().getLightLevel(), 0, 15);
         }
         return 0;
     }

--- a/src/main/java/thedarkcolour/exdeorum/blockentity/AbstractCrucibleBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/AbstractCrucibleBlockEntity.java
@@ -357,10 +357,14 @@ public abstract class AbstractCrucibleBlockEntity extends ETankBlockEntity {
                 var tank = crucible.tank;
 
                 if ((level.getGameTime() % 10L) == 0L) {
-                    short delta = (short) Math.min(crucible.solids, crucible.getMeltingRate());
+                    if (crucible.solids <= 0) return;
+
+                    int meltingRate = crucible.getMeltingRate();
 
                     // Skip if no heat
-                    if (delta <= 0) return;
+                    if (meltingRate <= 0) return;
+
+                    short delta = (short) Math.min(crucible.solids, meltingRate);
 
                     if (tank.getSpace() >= delta) {
                         // Remove solids

--- a/src/main/java/thedarkcolour/exdeorum/blockentity/LavaCrucibleBlockEntity.java
+++ b/src/main/java/thedarkcolour/exdeorum/blockentity/LavaCrucibleBlockEntity.java
@@ -36,6 +36,9 @@ public class LavaCrucibleBlockEntity extends AbstractCrucibleBlockEntity {
 
     @Override
     public int getMeltingRate() {
+        if (this.level == null) {
+            return 0;
+        }
         return RecipeUtil.getHeatValue(this.level.getBlockState(getBlockPos().below()));
     }
 

--- a/src/main/java/thedarkcolour/exdeorum/recipe/RecipeUtil.java
+++ b/src/main/java/thedarkcolour/exdeorum/recipe/RecipeUtil.java
@@ -444,7 +444,7 @@ public final class RecipeUtil {
     }
 
     public static int getHeatValue(BlockState state) {
-        return crucibleHeatRecipeCache.getValue(state);
+        return crucibleHeatRecipeCache == null ? 0 : crucibleHeatRecipeCache.getValue(state);
     }
 
     public static ObjectSet<Object2IntMap.Entry<BlockState>> getHeatSources() {


### PR DESCRIPTION
This PR makes crucible loading and ticking safer by avoiding world/block-entity lookups from code paths that may run during chunk loading or lighting.

Changes made:

* `AbstractCrucibleBlock#getLightEmission` no longer calls `level.getExistingBlockEntity(pos)` directly.
* Light emission still uses the crucible fluid light level when the block entity is already available from a loaded `LevelChunk`.
* `LevelChunk.EntityCreationType.CHECK` is used so light lookup does not create or force-resolve a block entity.
* `AbstractCrucibleBlockEntity.Ticker` now returns before calling `getMeltingRate()` when `solids <= 0`.
* `LavaCrucibleBlockEntity#getMeltingRate()` now returns `0` if `level` is null.
* `RecipeUtil#getHeatValue()` now returns `0` if the crucible heat recipe cache is unavailable.


I ran into a server startup hang during spawn preparation when a chunk containing a lava crucible was loaded. The server did not crash or print a useful error.. it simply stopped progressing during world loading.

This patch keeps the existing crucible behavior where possible, including fluid-based light emission, but avoids unsafe lookups during chunk loading and avoids unnecessary heat-source checks when the crucible is empty.
